### PR TITLE
BiasedDelay: crasher bugfix, and misc improvements

### DIFF
--- a/Contest/BiasedDelayPatch.hpp
+++ b/Contest/BiasedDelayPatch.hpp
@@ -13,7 +13,6 @@
 //  - B: feedback
 //  - C: bias: low..high
 //  - D: dry/wet mix
-//  - Push-button:
 //
 //  TODO:
 //  - see SimpleDelayPatch.hpp
@@ -51,78 +50,71 @@ class BiasedDelayPatch : public Patch {
   const float MED_BIAS;
   const float MAX_BIAS;
 
-  float* circularBuffer;
-  unsigned int bufferSize;
-  unsigned int writeIdx;
+  AudioBuffer* delayBuffer;
+  unsigned int delayBufIdx;
+  unsigned int oldDelayInSamples;
   
 public:
-  BiasedDelayPatch() : MIN_DELAY(0.01), MAX_DELAY(4), MIN_BIAS(0.5), MED_BIAS(1), MAX_BIAS(3), ramp(0.1), circularBuffer(NULL) {
+  BiasedDelayPatch() : MIN_DELAY(0.01), MAX_DELAY(2), MIN_BIAS(0.8), MED_BIAS(1), 
+    MAX_BIAS(1.5), delayBuffer(NULL), delayBufIdx(0) {
     registerParameter(PARAMETER_A, "Delay");
     registerParameter(PARAMETER_B, "Feedback");
     registerParameter(PARAMETER_C, "Bias");
     registerParameter(PARAMETER_D, "Dry/Wet");
-    memset(oldVal, 0, sizeof(oldVal));
 
-    AudioBuffer* buffer = createMemoryBuffer(1, MAX_DELAY * getSampleRate());
-    bufferSize = buffer->getSize();    
-    circularBuffer = buffer->getSamples(0);
+    delayBuffer = createMemoryBuffer(2, MAX_DELAY * getSampleRate());
   }
 
-//     if (circularBuffer==NULL)
-//     {
-//       bufferSize = MAX_DELAY * rate;
-//       circularBuffer = new float[bufferSize];
-//       memset(circularBuffer, 0, bufferSize*sizeof(float));
-//       writeIdx = 0;
-//     }
+  void processAudio(AudioBuffer &buffer){
 
-    void processAudio(AudioBuffer &buffer){
-
-    double rate = getSampleRate();
+    unsigned int delayInSamples = getDelayInSamples(PARAMETER_A);
+    float feedback = getParameterValue(PARAMETER_B);
+    float bias = getBiasExponent(PARAMETER_C);
+    float dryWetMix = getParameterValue(PARAMETER_D);
     
+    int bufSize = buffer.getSize();
+    int delayBufSize = delayBuffer->getSize();
 
-    unsigned int sampleDelay = getSampleDelay(getRampedParameterValue(PARAMETER_A), rate);
-    sampleDelay = min(sampleDelay, bufferSize);
-    float feedback = getRampedParameterValue(PARAMETER_B);
-    float bias = getBiasExponent(1 - getRampedParameterValue(PARAMETER_C));
-    float dryWetMix = getRampedParameterValue(PARAMETER_D);
+    for (int ch = 0; ch<buffer.getChannels(); ++ch)
+    {
+      float* buf = buffer.getSamples(ch);
+      float* delayBuf = delayBuffer->getSamples(ch);
+
+      unsigned int writeIdx = delayBufIdx;
+      int readIdx = delayBufIdx - delayInSamples;
+      while (readIdx<0) readIdx += delayBufSize;
+      int oldReadIdx = delayBufIdx - oldDelayInSamples;
+      while (oldReadIdx<0) oldReadIdx += delayBufSize;
+
+      for (int i=0; i<bufSize; ++i)
+      {
+        float delaySample = linearBlend(delayBuf[oldReadIdx], delayBuf[readIdx], (float)i/bufSize);
+        float v = buf[i] + delaySample * feedback;
+        v = applyBias(v, bias);
+        delayBuf[writeIdx] = min(1, max(-1, v)); // Guard: hard range limits.
+        buf[i] = linearBlend(buf[i], delaySample, dryWetMix);
     
-
-    int size = buffer.getSize();
-
- 	for(int ch = 0; ch<buffer.getChannels(); ++ch)
- 	{
-	    float* buf = buffer.getSamples(ch);
-
-	    for (int i=0; i<size; ++i)
-	    {
-	      float delaySample = circularBuffer[writeIdx];
-	      float v = buf[i] + circularBuffer[writeIdx] * feedback;
-	      v = applyBias(v, bias);
-	      circularBuffer[writeIdx] = min(1, max(-1, v)); // Guard: hard range limits.
-	      buf[i] = linearBlend(buf[i], delaySample, dryWetMix);
-
-	      writeIdx = (++writeIdx) % sampleDelay;
-	    }
-		
-  	}
-  }
-  
-  ~BiasedDelayPatch(){
-    delete(circularBuffer);
+        writeIdx = (++writeIdx) % delayBufSize;
+        readIdx = (++readIdx) % delayBufSize;
+      }
+    }
+    delayBufIdx = (delayBufIdx + bufSize) % delayBufSize;
+    oldDelayInSamples = delayInSamples;
   }
   
 private:
   
-  unsigned int getSampleDelay(float p1, float rate){
-    return (MIN_DELAY + p1 * (MAX_DELAY-MIN_DELAY)) * rate;
+  unsigned int getDelayInSamples(PatchParameterId id){
+    unsigned int minDelayInSamples = getSampleRate() * MIN_DELAY;
+    return minDelayInSamples + getParameterValue(id) * (delayBuffer->getSize() - minDelayInSamples);
   }
-
+  
   // Mapping p1 parameter ranges so that:
   // - full-left (0) is "low bias"
   // - centre (0.5) is "no bias"
   // - full-right (1.0) is "high bias"
-  float getBiasExponent(float p1){
+  float getBiasExponent(PatchParameterId id){
+    float p1 = 1 - getParameterValue(id);
     if (p1 < 0.5)
     { // min .. med
       p1 = p1 * 2; // [0..1] range
@@ -143,18 +135,6 @@ private:
   // Fade from a to b, over mix range [0..1]
   float linearBlend(float a, float b, float mix){
     return a * (1 - mix) + b * mix;
-  }
-
-  // Parameter ramping to reduce clicks.
-  
-  float oldVal[4];
-  float ramp; // 0..1
-  
-  float getRampedParameterValue(PatchParameterId id){
-    float val = getParameterValue(id);
-    float result = val * ramp + oldVal[id] * (1-ramp);
-    oldVal[id] = val;
-    return result;
   }
 };
 

--- a/includes.h
+++ b/includes.h
@@ -28,7 +28,7 @@
 #include "JotReverbPatch.hpp"
 #include "mdaPorts/MdaBandistoPatch.cpp"
 // #include "EnvelopeFilterPatch.hpp" /* too cpu intensive (sqrt...) */
-// #include "Contest/BiasedDelayPatch.hpp"  /* triggers NMI_Handler () */
+#include "Contest/BiasedDelayPatch.hpp"  /* triggers NMI_Handler () */
 // #include "Contest/JumpDelay.hpp" /* uses calloc and free */
 // #include "Contest/SampleJitterPatch.hpp" /* requires juce::Random */
 // #include "Contest/SirenPatch.hpp" /* causes assert_failed in DMA_GetFlagStatus() */

--- a/patches.cpp
+++ b/patches.cpp
@@ -21,7 +21,7 @@
   REGISTER_PATCH(EnvelopeFilterPatch, "Envelope Filter");
   REGISTER_PATCH(JotReverbPatch,"JotReverbPatch");
 //   REGISTER_PATCH(HighPassFilterPatch, "a High Pass Filter");
-//   REGISTER_PATCH(BiasedDelayPatch, "Contest/BiasedDelayPatch");
+  REGISTER_PATCH(BiasedDelayPatch, "Contest/BiasedDelayPatch");
 //   REGISTER_PATCH(JumpDelay, "Contest/JumpDelay");
 //   REGISTER_PATCH(SampleJitterPatch, "Contest/SampleJitterPatch");
 //   REGISTER_PATCH(SirenPatch, "Contest/SirenPatch");


### PR DESCRIPTION
Fixed the key bug: in the released version a variable remained uninitialised which caused a crash when loading. 

Additionally it seems the destructor caused problems/crashes too -- it simply deleted an allocated buffer. Looking at other official plugins I noticed that nobody ever actually deallocates their audio buffers, so I removed this code too.

Then took this as an opportunity for a review, made a generally improved version.
