### PR TITLE
Visual Studio compliance

### DIFF
--- a/SimpleDriveDelayPatch.hpp
+++ b/SimpleDriveDelayPatch.hpp
@@ -36,7 +36,7 @@
 class SimpleDelayPatch : public Patch {
 private:
   CircularBuffer delayBuffer;
-  int32_t delay;
+  int delay;
 public:
   SimpleDelayPatch() : delay(0)
   {
@@ -60,7 +60,7 @@ public:
       drive += 0.03;
       drive *= 40;
       
-    int32_t newDelay;
+    int newDelay;
     newDelay = delayTime * (delayBuffer.getSize()-1);
       
     float* x = buffer.getSamples(0);

--- a/WaveshaperPatch.hpp
+++ b/WaveshaperPatch.hpp
@@ -31,6 +31,10 @@
 
 #include "StompBox.h"
 
+#ifdef _MSC_VER
+#define lround roundFloatToInt
+#endif
+
 class WaveshaperPatch : public Patch {
 public:
   WaveshaperPatch(){


### PR DESCRIPTION
int32_t type and lround function do not exist in VS.
Tested with VS2010 and VS2012
