### PR TITLE
FlangerPatch: Add support for stereo devices

### DIFF
--- a/FlangerPatch.hpp
+++ b/FlangerPatch.hpp
@@ -33,13 +33,16 @@
 
 class FlangerPatch : public Patch {
 private:
-    CircularBuffer delayBuffer;
+    CircularBuffer **delayBuffers;
     float rate, depth, feedback, phase;
     
 public:
   FlangerPatch(){
-    AudioBuffer* buffer = createMemoryBuffer(1, FLANGER_BUFFER_SIZE);
-    delayBuffer.initialise(buffer->getSamples(0), buffer->getSize());
+    delayBuffers = (CircularBuffer **) calloc(2, sizeof(CircularBuffer *));
+    for (int ch = 0; ch < 2; ch++)
+    {
+      delayBuffers[ch] = CircularBuffer::create(FLANGER_BUFFER_SIZE);
+    }
     registerParameter(PARAMETER_A, "Rate");
     registerParameter(PARAMETER_B, "Depth");
     registerParameter(PARAMETER_C, "Feedback");
@@ -51,7 +54,7 @@ public:
     if ( phase >= 1.0 ) {
         phase -= 1.0;
     }
-    return sinf(phase*(2*M_PI));    //sine function
+    return sinf(phase*(2*M_PI)) * 0.5 + 0.5;    // sine function between 0..1
   };
   void processAudio(AudioBuffer &buffer){
     int size = buffer.getSize();
@@ -59,14 +62,14 @@ public:
       
     rate     = getParameterValue(PARAMETER_A) * 0.000005f; // flanger needs slow rate
     depth    = getParameterValue(PARAMETER_B);
-    feedback = getParameterValue(PARAMETER_C)* 0.707; // so we keep a -3dB summation of the delayed signal
+    feedback = getParameterValue(PARAMETER_C) * 0.9;
       
     for (int ch = 0; ch<buffer.getChannels(); ++ch) {
         for (int i = 0 ; i < size; i++) {
             float* buf = buffer.getSamples(ch);
-            delaySamples = (depth * modulate(rate)) * (delayBuffer.getSize()-1); // compute delay according to rate and depth
-            buf[i] += feedback * delayBuffer.read(delaySamples); // add scaled delayed signal to dry signal
-            delayBuffer.write(buf[i]); // update delay buffer
+            delaySamples = (depth * modulate(rate)) * (delayBuffers[ch]->getSize()-1) + 1; // compute delay according to rate and depth
+            buf[i] += feedback * delayBuffers[ch]->read(delaySamples); // add scaled delayed signal to dry signal
+            delayBuffers[ch]->write(buf[i]); // update delay buffer
         }
     }
   }


### PR DESCRIPTION
Previously, the flanger would read twice from the same `delayBuffer` when used with a stereo device, causing audible glitches. Now allocate two `delayBuffer`s and use accordingly.